### PR TITLE
Aligning SONiC code with sff8024 spec 

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -2034,34 +2034,34 @@ class CmisApi(XcvrApi):
             key = "{}_{}".format(consts.HOST_ELECTRICAL_INTERFACE, app)
             val = dic.get(key)
             if val in [None, 'Unknown', 'Undefined']:
-                break
+                continue
             buf['host_electrical_interface_id'] = val
 
             prefix = map.get(self.xcvr_eeprom.read(consts.MEDIA_TYPE_FIELD))
             if prefix is None:
-                break
+                continue
             key = "{}_{}".format(prefix, app)
             val = dic.get(key)
             if val in [None, 'Unknown']:
-                break
+                continue
             buf['module_media_interface_id'] = val
 
             key = "{}_{}".format(consts.MEDIA_LANE_COUNT, app)
             val = dic.get(key)
             if val is None:
-                break
+                continue
             buf['media_lane_count'] = val
 
             key = "{}_{}".format(consts.HOST_LANE_COUNT, app)
             val = dic.get(key)
             if val is None:
-                break
+                continue
             buf['host_lane_count'] = val
 
             key = "{}_{}".format(consts.HOST_LANE_ASSIGNMENT_OPTION, app)
             val = dic.get(key)
             if val is None:
-                break
+                continue
             buf['host_lane_assignment_options'] = val
 
             key = "{}_{}".format(consts.MEDIA_LANE_ASSIGNMENT_OPTION, app)

--- a/sonic_platform_base/sonic_xcvr/codes/public/sff8024.py
+++ b/sonic_platform_base/sonic_xcvr/codes/public/sff8024.py
@@ -183,6 +183,7 @@ class Sff8024(XcvrCodes):
         5: 'base_t_media_interface'
     }
 
+    # Host Electrical Interface IDs
     HOST_ELECTRICAL_INTERFACE = {
         0: 'Undefined',
         1: '1000BASE -CX(Clause 39)',
@@ -250,14 +251,26 @@ class Sff8024(XcvrCodes):
         64: 'FOIC4.8 (ITU-T G.709.1 G.Sup58)',
         65: 'CAUI-4 C2M (Annex 83E) without FEC',
         66: 'CAUI-4 C2M (Annex 83E) with RS(528,514) FEC',
+        67: '50GBASE-CR2 (Ethernet Technology Consortium) with RS(528,514) (Clause 91) FEC',
+        68: '50GBASE-CR2 (Ethernet Technology Consortium) with BASE-R (Clause 74), Fire code FEC',
+        69: '50GBASE-CR2 (Ethernet Technology Consortium) with no FEC',
+        70: '100GBASE-CR1 (Clause 162)',
+        71: '200GBASE-CR2 (Clause 162)',
+        72: '400GBASE-CR4 (Clause 162)',
+        73: '800G-ETC-CR8',
+        74: '128GFC (FC-PI-8)',
         75: '100GAUI-1-S C2M (Annex 120G)',
         76: '100GAUI-1-L C2M (Annex 120G)',
+        77: '200GAUI-2-S C2M (Annex 120G)',
+        78: '200GAUI-2-L C2M (Annex 120G)',
         79: '400GAUI-4-S C2M (Annex 120G)',
         80: '400GAUI-4-L C2M (Annex 120G)',
         81: '800G S C2M (placeholder)',
-        82: '800G L C2M (placeholder)'
+        82: '800G L C2M (placeholder)',
+        83: 'OTL4.2'
     }
 
+    # MMF media interface IDs
     NM_850_MEDIA_INTERFACE = {
         0: 'Undefined',
         1: '10GBASE-SW (Clause 52)',
@@ -278,16 +291,23 @@ class Sff8024(XcvrCodes):
         16: '400GBASE-SR8 (Clause 138)',
         17: '400G-SR4 (Placeholder)',
         18: '800G-SR8 (Placeholder)',
-        26: '400GBASE-SR4.2 (Clause 150) (400GE BiDi)',
         19: '8GFC-MM (FC-PI-4)',
         20: '10GFC-MM (10GFC)',
         21: '16GFC-MM (FC-PI-5)',
         22: '32GFC-MM (FC-PI-6)',
         23: '64GFC-MM (FC-PI 7)',
         24: '128GFC-MM4 (FC-PI-6P)',
-        25: '256GFC-MM4 (FC-PI-7P)'
+        25: '256GFC-MM4 (FC-PI-7P)',
+        26: '400GBASE-SR4.2 (Clause 150) (400GE BiDi)',
+        27: '200G-SR2 (Clause 167)',
+        28: '128GFC-MM (FC-PI-8)',
+        29: '100G-VR1 (Clause 167)',
+        30: '200G-VR2 (Clause 167)',
+        31: '400G-VR4 (Clause 167)',
+        32: '800G-VR8 (Placeholder)'
     }
 
+    # SMF media interface IDs
     SM_MEDIA_INTERFACE = {
         0: 'Undefined',
         1: '10GBASE-LW (Cl 52)',
@@ -326,9 +346,7 @@ class Sff8024(XcvrCodes):
         34: '32GFC-SM (FC-PI-6)',
         35: '64GFC-SM (FC-PI-7)',
         36: '128GFC-PSM4 (FC-PI-6P)',
-        37: '256GFC-PSM4 (FC-PI-7P)',
         38: '128GFC-CWDM4 (FC-PI-6P)',
-        39: '256GFC-CWDM4 (FC-PI-7P)',
         44: '4I1-9D1F (G.959.1)',
         45: '4L1-9C1F (G.959.1)',
         46: '4L1-9D1F (G.959.1)',
@@ -337,6 +355,7 @@ class Sff8024(XcvrCodes):
         49: '4I1-4D1F (G.959.1)',
         50: '8R1-4D1F (G.959.1)',
         51: '8I1-4D1F (G.959.1)',
+        52: '100G CWDM4-OCP',
         56: '10G-SR',
         57: '10G-LR',
         58: '25G-SR',
@@ -345,18 +364,40 @@ class Sff8024(XcvrCodes):
         61: '25G-LR-BiDi',
         62: '400ZR, DWDM, amplified',
         63: '400ZR, Single Wavelength, Unamplified',
+        64: '50GBASE-ER (Cl 139)',
+        65: '200GBASE-ER4 (Cl 122)',
+        66: '400GBASE-ER8 (Cl 122)',
+        67: '400GBASE-LR4-6 (Cl 151)',
+        68: '100GBASE-ZR (Cl 154)',
+        69: '128GFC-SM (FC-PI-8)',
         70: 'ZR400-OFEC-16QAM',
         71: 'ZR300-OFEC-8QAM',
         72: 'ZR200-OFEC-QPSK',
-        73: 'ZR100-OFEC-QPSK'
+        73: 'ZR100-OFEC-QPSK',
+        74: '100G-LR1-20',
+        75: '100G-ER1-30',
+        76: '100G-ER1-40',
+        77: '400GBASE-ZR (Cl 156)',
+        78: '10GBASE-BR (Cl 158)',
+        79: '25GBASE-BR (Cl 159)',
+        80: '50GBASE-BR (Cl 160)',
+        81: 'FOIC1.4-DO (G.709.3/Y.1331.3)',
+        82: 'FOIC2.8-DO (G.709.3/Y.1331.3)',
+        83: 'FOIC4.8-DO (G.709.3/Y.1331.3)',
+        84: 'FOIC2.4-DO (G.709.3/Y.1331.3)',
+        85: '400GBASE-DR4-2 (placeholder)',
+        86: '800GBASE-DR8 (placeholder)',
+        87: '800GBASE-DR8-2 (placeholder)'
     }
 
+    # Passive and Linear Active Copper Cable and Passive Loopback media interface codes
     PASSIVE_COPPER_MEDIA_INTERFACE = {
         0: 'Undefined',
         1: 'Copper cable',
-        2: 'Passive Loopback module'
+        191: 'Passive Loopback module'
     }
 
+    # Limiting and Retimed Active Cable assembly and Active Loopback media interface codes
     ACTIVE_CABLE_MEDIA_INTERFACE = {
         0: 'Undefined',
         1: 'Active Cable assembly with BER < 10^-12',
@@ -366,12 +407,16 @@ class Sff8024(XcvrCodes):
         191: 'Active Loopback module'
     }
 
+    # BASE-T media interface codes
     BASE_T_MEDIA_INTERFACE = {
         0: 'Undefined',
         1: '1000BASE-T (Clause 40)',
         2: '2.5GBASE-T (Clause 126)',
         3: '5GBASE-T (Clause 126)',
-        4: '10GBASE-T (Clause 55)'
+        4: '10GBASE-T (Clause 55)',
+        5: '25GBASE-T (Clause 113)',
+        6: '40GBASE-T (Clause 113)',
+        7: '50GBASE-T (Placeholder)'
     }
 
     # TODO: Add other codes

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -2172,6 +2172,91 @@ class TestCmis(object):
         assert result[1]['host_lane_assignment_options'] == 0x01
         assert result[1]['media_lane_assignment_options'] == 0x02
 
+    def test_get_application_advertisement_apps_with_missing_data(self):
+        self.api.xcvr_eeprom.read = MagicMock()
+        self.api.xcvr_eeprom.read.side_effect = [
+            {
+                consts.HOST_ELECTRICAL_INTERFACE + "_1": "400GAUI-8 C2M (Annex 120E)",
+                consts.HOST_ELECTRICAL_INTERFACE + "_2": None,
+                consts.HOST_ELECTRICAL_INTERFACE + "_3": "200GAUI-8 C2M (Annex 120C)",
+                consts.HOST_ELECTRICAL_INTERFACE + "_4": "40GBASE-CR4 (Clause 85)",
+                consts.HOST_ELECTRICAL_INTERFACE + "_5": "50GBASE-CR (Clause 126)",
+                consts.HOST_ELECTRICAL_INTERFACE + "_6": "200GBASE-CR4 (Clause 136)",
+                consts.HOST_ELECTRICAL_INTERFACE + "_7": "200GAUI-2-S C2M (Annex 120G)",
+                consts.HOST_ELECTRICAL_INTERFACE + "_8": "800G S C2M (placeholder)",
+
+                consts.MODULE_MEDIA_INTERFACE_SM + "_1": "400GBASE-DR4 (Cl 124)",
+                consts.MODULE_MEDIA_INTERFACE_SM + "_2": "25GBASE-LR (Cl 114)",
+                consts.MODULE_MEDIA_INTERFACE_SM + "_3": "40GBASE-LR4 (Cl 87)",
+                consts.MODULE_MEDIA_INTERFACE_SM + "_4": None,
+                consts.MODULE_MEDIA_INTERFACE_SM + "_5": "10GBASE-LR (Cl 52)",
+                consts.MODULE_MEDIA_INTERFACE_SM + "_6": "50GBASE-FR (Cl 139)",
+                consts.MODULE_MEDIA_INTERFACE_SM + "_7": "100GBASE-DR (Cl 140)",
+                consts.MODULE_MEDIA_INTERFACE_SM + "_8": "800GBASE-DR8 (placeholder)",
+
+                consts.MEDIA_LANE_COUNT + "_1": 4,
+                consts.MEDIA_LANE_COUNT + "_2": 4,
+                consts.MEDIA_LANE_COUNT + "_3": 4,
+                consts.MEDIA_LANE_COUNT + "_4": 4,
+                consts.MEDIA_LANE_COUNT + "_5": None,
+                consts.MEDIA_LANE_COUNT + "_6": 4,
+                consts.MEDIA_LANE_COUNT + "_7": 4,
+                consts.MEDIA_LANE_COUNT + "_8": 4,
+
+                consts.HOST_LANE_COUNT + "_1": 8,
+                consts.HOST_LANE_COUNT + "_2": 8,
+                consts.HOST_LANE_COUNT + "_3": 8,
+                consts.HOST_LANE_COUNT + "_4": 8,
+                consts.HOST_LANE_COUNT + "_5": 8,
+                consts.HOST_LANE_COUNT + "_6": 8,
+                consts.HOST_LANE_COUNT + "_7": 8,
+                consts.HOST_LANE_COUNT + "_8": None,
+
+                consts.HOST_LANE_ASSIGNMENT_OPTION + "_1": 0x01,
+                consts.HOST_LANE_ASSIGNMENT_OPTION + "_2": 0x01,
+                consts.HOST_LANE_ASSIGNMENT_OPTION + "_3": 0x01,
+                consts.HOST_LANE_ASSIGNMENT_OPTION + "_4": 0x01,
+                consts.HOST_LANE_ASSIGNMENT_OPTION + "_5": 0x01,
+                consts.HOST_LANE_ASSIGNMENT_OPTION + "_6": 0x01,
+                consts.HOST_LANE_ASSIGNMENT_OPTION + "_7": None,
+                consts.HOST_LANE_ASSIGNMENT_OPTION + "_8": 0x01,
+
+                consts.MEDIA_LANE_ASSIGNMENT_OPTION + "_1": 0x02,
+                consts.MEDIA_LANE_ASSIGNMENT_OPTION + "_2": 0x02,
+                consts.MEDIA_LANE_ASSIGNMENT_OPTION + "_3": 0x02,
+                consts.MEDIA_LANE_ASSIGNMENT_OPTION + "_4": 0x02,
+                consts.MEDIA_LANE_ASSIGNMENT_OPTION + "_5": 0x02,
+                consts.MEDIA_LANE_ASSIGNMENT_OPTION + "_6": 0x02,
+                consts.MEDIA_LANE_ASSIGNMENT_OPTION + "_7": 0x02,
+                consts.MEDIA_LANE_ASSIGNMENT_OPTION + "_8": 0x02
+            },
+            Sff8024.MODULE_MEDIA_TYPE[2],
+            None,
+            Sff8024.MODULE_MEDIA_TYPE[2],
+            Sff8024.MODULE_MEDIA_TYPE[2],
+            Sff8024.MODULE_MEDIA_TYPE[2],
+            Sff8024.MODULE_MEDIA_TYPE[2],
+            Sff8024.MODULE_MEDIA_TYPE[2],
+            Sff8024.MODULE_MEDIA_TYPE[2]
+        ]
+        result = self.api.get_application_advertisement()
+
+        assert len(result) == 2
+
+        assert result[1]['host_electrical_interface_id'] == '400GAUI-8 C2M (Annex 120E)'
+        assert result[1]['module_media_interface_id'] == '400GBASE-DR4 (Cl 124)'
+        assert result[1]['host_lane_count'] == 8
+        assert result[1]['media_lane_count'] == 4
+        assert result[1]['host_lane_assignment_options'] == 0x01
+        assert result[1]['media_lane_assignment_options'] == 0x02
+
+        assert result[6]['host_electrical_interface_id'] == '200GBASE-CR4 (Clause 136)'
+        assert result[6]['module_media_interface_id'] == '50GBASE-FR (Cl 139)'
+        assert result[6]['host_lane_count'] == 8
+        assert result[6]['media_lane_count'] == 4
+        assert result[6]['host_lane_assignment_options'] == 0x01
+        assert result[6]['media_lane_assignment_options'] == 0x02
+
     def test_get_application_advertisement_non_support(self):
         self.api.xcvr_eeprom.read = MagicMock(return_value = None)
         self.api.is_flat_memory = MagicMock(return_value = False)


### PR DESCRIPTION
#### Description
I updated sff8024.py to align with the SFF8024 spec by implementing fixes and additions. Additionally, I resolved an issue in the method responsible for retrieving the application advertisement list from the EEPROM of CMIS modules.

#### Motivation and Context
We encountered an issue with the application advertisement list retrieved from the get_application_advertisement() method for a specific module. Despite the EEPROM indicating support for 6 applications, the method returned only one application. This discrepancy appeared because the EEPROM's application advertisement list was missing information for the SECOND application. The implementation of get_application_advertisement() in cmis.py would terminate prematurely if information was missing for any application, causing subsequent applications to be overlooked.
To address this issue, this PR introduces two changes:

1. Updates the get_application_advertisement() method to continue processing even if information is missing for an application, proceeding to the next application instead.
2. Updates sff8024.py to include information for ALL applications specified in the SFF8024 spec (including the application that was missing in the original issue ofc)

#### How Has This Been Tested?
I verified that the missing application in sff8024.py could be successfully detected in the module's EEPROM application advertisement list.

#### Additional Information (Optional)

