### PR TITLE
Add XcvrBase as shared superclass for SfpBase and CpoBase

### DIFF
--- a/sonic_platform_base/__init__.py
+++ b/sonic_platform_base/__init__.py
@@ -7,6 +7,7 @@ from . import module_base
 from . import platform_base
 from . import psu_base
 from . import sfp_base
+from . import xcvr_base
 from . import thermal_base
 from . import sensor_base
 from . import watchdog_base

--- a/sonic_platform_base/sfp_base.py
+++ b/sonic_platform_base/sfp_base.py
@@ -6,12 +6,12 @@
 """
 
 import sys
-from . import device_base
 
+from .xcvr_base import XcvrBase
 from .sonic_xcvr.xcvr_api_factory import XcvrApiFactory
 from .sonic_xcvr.eeprom_rw import EepromReadWriteMixin
 
-class SfpBase(device_base.DeviceBase, EepromReadWriteMixin):
+class SfpBase(XcvrBase, EepromReadWriteMixin):
     """
     Abstract base class for interfacing with a SFP module
     """
@@ -124,94 +124,6 @@ class SfpBase(device_base.DeviceBase, EepromReadWriteMixin):
                              index, len(self._thermal_list)-1))
 
         return thermal
-
-    def get_transceiver_info(self):
-        """
-        Retrieves transceiver info of this SFP
-
-        Returns:
-            A dict which contains following keys/values :
-        ================================================================================
-        keys                       |Value Format   |Information
-        ---------------------------|---------------|----------------------------
-        type                       |1*255VCHAR     |type of SFP
-        type_abbrv_name            |1*255VCHAR     |type of SFP, abbreviated
-        hardware_rev               |1*255VCHAR     |hardware version of SFP
-        vendor_rev                 |1*255VCHAR     |vendor revision of SFP
-        serial                     |1*255VCHAR     |serial number of the SFP
-        manufacturer               |1*255VCHAR     |SFP vendor name
-        model                      |1*255VCHAR     |SFP model name
-        connector                  |1*255VCHAR     |connector information
-        encoding                   |1*255VCHAR     |encoding information
-        ext_identifier             |1*255VCHAR     |extend identifier
-        ext_rateselect_compliance  |1*255VCHAR     |extended rateSelect compliance
-        cable_length               |INT            |cable length in m
-        nominal_bit_rate           |INT            |nominal bit rate by 100Mbs
-        specification_compliance   |1*255VCHAR     |specification compliance
-        vendor_date                |1*255VCHAR     |vendor date
-        vendor_oui                 |1*255VCHAR     |vendor OUI
-        application_advertisement  |1*255VCHAR     |supported applications advertisement
-        ================================================================================
-        """
-        raise NotImplementedError
-
-    def get_transceiver_bulk_status(self):
-        """
-        Retrieves transceiver bulk status of this SFP
-
-        Returns:
-            A dict which contains following keys/values :
-        ========================================================================
-        keys                       |Value Format   |Information
-        ---------------------------|---------------|----------------------------
-        rx_los                     |BOOLEAN        |RX loss-of-signal status, True if has RX los, False if not.
-        tx_fault                   |BOOLEAN        |TX fault status, True if has TX fault, False if not.
-        reset_status               |BOOLEAN        |reset status, True if SFP in reset, False if not.
-        lp_mode                    |BOOLEAN        |low power mode status, True in lp mode, False if not.
-        temperature                |INT            |module temperature in Celsius
-        voltage                    |INT            |supply voltage in mV
-        tx<n>bias                  |INT            |TX Bias Current in mA, n is the channel number,
-                                   |               |for example, tx2bias stands for tx bias of channel 2.
-        rx<n>power                 |INT            |received optical power in mW, n is the channel number,
-                                   |               |for example, rx2power stands for rx power of channel 2.
-        tx<n>power                 |INT            |TX output power in mW, n is the channel number,
-                                   |               |for example, tx2power stands for tx power of channel 2.
-        ========================================================================
-        """
-        raise NotImplementedError
-
-    def get_transceiver_threshold_info(self):
-        """
-        Retrieves transceiver threshold info of this SFP
-
-        Returns:
-            A dict which contains following keys/values :
-        ========================================================================
-        keys                       |Value Format   |Information
-        ---------------------------|---------------|----------------------------
-        temphighalarm              |FLOAT          |High Alarm Threshold value of temperature in Celsius.
-        templowalarm               |FLOAT          |Low Alarm Threshold value of temperature in Celsius.
-        temphighwarning            |FLOAT          |High Warning Threshold value of temperature in Celsius.
-        templowwarning             |FLOAT          |Low Warning Threshold value of temperature in Celsius.
-        vcchighalarm               |FLOAT          |High Alarm Threshold value of supply voltage in mV.
-        vcclowalarm                |FLOAT          |Low Alarm Threshold value of supply voltage in mV.
-        vcchighwarning             |FLOAT          |High Warning Threshold value of supply voltage in mV.
-        vcclowwarning              |FLOAT          |Low Warning Threshold value of supply voltage in mV.
-        rxpowerhighalarm           |FLOAT          |High Alarm Threshold value of received power in dBm.
-        rxpowerlowalarm            |FLOAT          |Low Alarm Threshold value of received power in dBm.
-        rxpowerhighwarning         |FLOAT          |High Warning Threshold value of received power in dBm.
-        rxpowerlowwarning          |FLOAT          |Low Warning Threshold value of received power in dBm.
-        txpowerhighalarm           |FLOAT          |High Alarm Threshold value of transmit power in dBm.
-        txpowerlowalarm            |FLOAT          |Low Alarm Threshold value of transmit power in dBm.
-        txpowerhighwarning         |FLOAT          |High Warning Threshold value of transmit power in dBm.
-        txpowerlowwarning          |FLOAT          |Low Warning Threshold value of transmit power in dBm.
-        txbiashighalarm            |FLOAT          |High Alarm Threshold value of tx Bias Current in mA.
-        txbiaslowalarm             |FLOAT          |Low Alarm Threshold value of tx Bias Current in mA.
-        txbiashighwarning          |FLOAT          |High Warning Threshold value of tx Bias Current in mA.
-        txbiaslowwarning           |FLOAT          |Low Warning Threshold value of tx Bias Current in mA.
-        ========================================================================
-        """
-        raise NotImplementedError
 
     def get_reset_status(self):
         """

--- a/sonic_platform_base/sonic_xcvr/cpo/cpo_base.py
+++ b/sonic_platform_base/sonic_xcvr/cpo/cpo_base.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Optional
 
+from sonic_platform_base.xcvr_base import XcvrBase
 from sonic_platform_base.sonic_xcvr.xcvr_eeprom import XcvrEeprom
 from sonic_platform_base.sonic_xcvr.eeprom_rw import EepromReadWriteMixin
 
@@ -55,7 +56,7 @@ class CpoDeviceBase(EepromReadWriteMixin):
         return self._api
 
 
-class CpoBase:
+class CpoBase(XcvrBase):
     def __init__(self, hardware_id: CpoHardwareId, oe: "OeBase", elsfp: "ElsfpBase"):
         self.hardware_id = hardware_id
         self.oe = oe

--- a/sonic_platform_base/xcvr_base.py
+++ b/sonic_platform_base/xcvr_base.py
@@ -1,0 +1,95 @@
+from . import device_base
+
+
+class XcvrBase(device_base.DeviceBase):
+    """
+    Abstract base class for interfacing with a transceiver module
+    """
+
+    def get_transceiver_info(self):
+        """
+        Retrieves transceiver info of this transceiver
+
+        Returns:
+            A dict which contains following keys/values :
+        ================================================================================
+        keys                       |Value Format   |Information
+        ---------------------------|---------------|----------------------------
+        type                       |1*255VCHAR     |type of SFP
+        type_abbrv_name            |1*255VCHAR     |type of SFP, abbreviated
+        hardware_rev               |1*255VCHAR     |hardware version of SFP
+        vendor_rev                 |1*255VCHAR     |vendor revision of SFP
+        serial                     |1*255VCHAR     |serial number of the SFP
+        manufacturer               |1*255VCHAR     |SFP vendor name
+        model                      |1*255VCHAR     |SFP model name
+        connector                  |1*255VCHAR     |connector information
+        encoding                   |1*255VCHAR     |encoding information
+        ext_identifier             |1*255VCHAR     |extend identifier
+        ext_rateselect_compliance  |1*255VCHAR     |extended rateSelect compliance
+        cable_length               |INT            |cable length in m
+        nominal_bit_rate           |INT            |nominal bit rate by 100Mbs
+        specification_compliance   |1*255VCHAR     |specification compliance
+        vendor_date                |1*255VCHAR     |vendor date
+        vendor_oui                 |1*255VCHAR     |vendor OUI
+        application_advertisement  |1*255VCHAR     |supported applications advertisement
+        ================================================================================
+        """
+        raise NotImplementedError
+
+    def get_transceiver_bulk_status(self):
+        """
+        Retrieves transceiver bulk status of this transceiver
+
+        Returns:
+            A dict which contains following keys/values :
+        ========================================================================
+        keys                       |Value Format   |Information
+        ---------------------------|---------------|----------------------------
+        rx_los                     |BOOLEAN        |RX loss-of-signal status, True if has RX los, False if not.
+        tx_fault                   |BOOLEAN        |TX fault status, True if has TX fault, False if not.
+        reset_status               |BOOLEAN        |reset status, True if SFP in reset, False if not.
+        lp_mode                    |BOOLEAN        |low power mode status, True in lp mode, False if not.
+        temperature                |INT            |module temperature in Celsius
+        voltage                    |INT            |supply voltage in mV
+        tx<n>bias                  |INT            |TX Bias Current in mA, n is the channel number,
+                                   |               |for example, tx2bias stands for tx bias of channel 2.
+        rx<n>power                 |INT            |received optical power in mW, n is the channel number,
+                                   |               |for example, rx2power stands for rx power of channel 2.
+        tx<n>power                 |INT            |TX output power in mW, n is the channel number,
+                                   |               |for example, tx2power stands for tx power of channel 2.
+        ========================================================================
+        """
+        raise NotImplementedError
+
+    def get_transceiver_threshold_info(self):
+        """
+        Retrieves transceiver threshold info of this transceiver
+
+        Returns:
+            A dict which contains following keys/values :
+        ========================================================================
+        keys                       |Value Format   |Information
+        ---------------------------|---------------|----------------------------
+        temphighalarm              |FLOAT          |High Alarm Threshold value of temperature in Celsius.
+        templowalarm               |FLOAT          |Low Alarm Threshold value of temperature in Celsius.
+        temphighwarning            |FLOAT          |High Warning Threshold value of temperature in Celsius.
+        templowwarning             |FLOAT          |Low Warning Threshold value of temperature in Celsius.
+        vcchighalarm               |FLOAT          |High Alarm Threshold value of supply voltage in mV.
+        vcclowalarm                |FLOAT          |Low Alarm Threshold value of supply voltage in mV.
+        vcchighwarning             |FLOAT          |High Warning Threshold value of supply voltage in mV.
+        vcclowwarning              |FLOAT          |Low Warning Threshold value of supply voltage in mV.
+        rxpowerhighalarm           |FLOAT          |High Alarm Threshold value of received power in dBm.
+        rxpowerlowalarm            |FLOAT          |Low Alarm Threshold value of received power in dBm.
+        rxpowerhighwarning         |FLOAT          |High Warning Threshold value of received power in dBm.
+        rxpowerlowwarning          |FLOAT          |Low Warning Threshold value of received power in dBm.
+        txpowerhighalarm           |FLOAT          |High Alarm Threshold value of transmit power in dBm.
+        txpowerlowalarm            |FLOAT          |Low Alarm Threshold value of transmit power in dBm.
+        txpowerhighwarning         |FLOAT          |High Warning Threshold value of transmit power in dBm.
+        txpowerlowwarning          |FLOAT          |Low Warning Threshold value of transmit power in dBm.
+        txbiashighalarm            |FLOAT          |High Alarm Threshold value of tx Bias Current in mA.
+        txbiaslowalarm             |FLOAT          |Low Alarm Threshold value of tx Bias Current in mA.
+        txbiashighwarning          |FLOAT          |High Warning Threshold value of tx Bias Current in mA.
+        txbiaslowwarning           |FLOAT          |Low Warning Threshold value of tx Bias Current in mA.
+        ========================================================================
+        """
+        raise NotImplementedError


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
Introduce XcvrBase as a common superclass for SfpBase and CpoBase, with shared transceiver API methods moved out of SfpBase:

Original chain:

      DeviceBase
        └── SfpBase (+ EepromReadWriteMixin)
              └── SfpOptoeBase (+ OptoeEepromReadWriteMixin)
      CpoBase                    ← no superclass

New suggested chain:

      DeviceBase
        └── XcvrBase
            ├── SfpBase (+ EepromReadWriteMixin)
            │     └── SfpOptoeBase
            └── CpoBase

#### Motivation and Context
CPO and SFP are different transceiver types, but chassis, xcvrd, and other SONiC components still expect the same port-facing API for both. CpoBase should not depend on the SfpBase/SFP inheritance chain, yet both types still need to expose shared behavior. That shared functionality belongs in a common ancestor; otherwise we either duplicate code or keep CPO coupled to SFP for methods it does not semantically own.

This PR introduces XcvrBase as that ancestor and moves an initial set of three methods into it. That list is intentionally partial - the goal is to agree on the approach before identifying every function that must be shared between SfpBase and CpoBase.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)

